### PR TITLE
Remove unused test dependency declarations

### DIFF
--- a/ament_build_type_gradle/package.xml
+++ b/ament_build_type_gradle/package.xml
@@ -13,11 +13,6 @@
   <build_depend>ament_java_resources</build_depend>
   <exec_depend>ament_java_resources</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_pep257</test_depend>
-  <test_depend>ament_pep8</test_depend>
-  <test_depend>ament_pyflakes</test_depend>
-
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
When following install instructions for ros2-java, rosdep cannot resolve 'ament_pep8'.
Since we are not actually running any tests for this package, remove all test dependency declarations.